### PR TITLE
fix: Make opening chat from direct link/bookmark work

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -17,6 +17,11 @@
       "folder": "/",
       "index": "index.html",
       "public": false
+    },
+    "/web": {
+      "folder": "/",
+      "index": "index.html",
+      "public": false
     }
   },
   "permissions": {


### PR DESCRIPTION
Twake Chat routing starts all link with "/web/" and then add browser routing like "#/rooms". So when clicking on a direct link (for example from a bookmark), we need to be able to access "/web/#/rooms" so we need to add "/web" in manifest so the stack does not return a 404.

We removed this one in 632b84e06239f8bc9acc99769704748d52afc6d2.