### PR TITLE
feat: Update manifest wording to Twake

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,5 +1,6 @@
 {
   "name": "Chat",
+  "name_prefix": "Twake",
   "slug": "chat",
   "version": "0.1.0",
   "type": "webapp",
@@ -9,8 +10,8 @@
   "source": "https://github.com/cozy/cozy-twakechat",
   "editor": "Cozy",
   "developer": {
-    "name": "Cozy Cloud",
-    "url": "https://cozy.io"
+    "name": "Twake Workplace",
+    "url": "https://twake.app"
   },
   "routes": {
     "/": {


### PR DESCRIPTION
What I did not change :
- "editor": "Cozy" because it is used in the registry
- "category": "cozy" because it is a keyword that only appears in URL (which does not seem important) and is translated to "Essentials" anyway in Cozy Store
- GitHub repository