### PR TITLE
fix: Correct iframe height on mobile

### DIFF
--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -5,9 +5,13 @@
     overscroll-behavior-y none
     overflow-y hidden
 
+// We need !important to override default style added by cozy-ui.
+
+html
+    height 100% !important // @stylint ignore
+
 body
-    display flex
-    height 100vh
+    height 100% !important // @stylint ignore
 
 iframe
     +medium-screen()


### PR DESCRIPTION
We used 100vh to set the root height but Chrome Mobile does not take into account the URL bar in 100vh whereas this URL bar can change the available height when it is displayed or not.

We need to set 100% to the html element to be responsive to the real available height (see https://developer.chrome.com/blog/url-bar-resizing)